### PR TITLE
Add scrollytelling story mode

### DIFF
--- a/scrolly.html
+++ b/scrolly.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/images/rare-logo.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+    <title>Heat Wave Story Mode</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="src/scrolly/main.jsx"></script>
+  </body>
+</html>

--- a/src/scrolly/ScrollyApp.jsx
+++ b/src/scrolly/ScrollyApp.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useRef, useState } from 'react'
+import '../styles/scrolly.css'
+
+const sections = [
+  {
+    title: "Grey's Anatomy & Heat Waves",
+    text: "Can a TV drama help us stay safe when the weather gets dangerously hot? Let's find out.",
+    image: '/images/greys-anatomy-banner_with_text.png',
+    alt: "Grey's Anatomy banner with doctors"
+  },
+  {
+    title: 'What We Learned',
+    text: 'People who watched a heatwave storyline remembered more lifesaving tips.',
+    extra: 'On average, viewers recalled about two more pieces of heat safety advice than non-viewers.',
+    image: '/images/eyeinspired.jpg',
+    alt: 'Illustration of a blazing sun'
+  },
+  {
+    title: 'Why It Matters',
+    text: 'Extreme heat already kills more people than any other weather hazard in the U.S. Knowledge can save lives.',
+    image: '/images/farmernick.jpg',
+    alt: 'A farmer wiping sweat from his brow on a hot day'
+  }
+]
+
+function ScrollyApp() {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [showMore, setShowMore] = useState(false)
+  const stepRefs = useRef([])
+
+  useEffect(() => {
+    stepRefs.current = stepRefs.current.slice(0, sections.length)
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const index = Number(entry.target.dataset.index)
+            setActiveIndex(index)
+          }
+        })
+      },
+      { threshold: 0.5 }
+    )
+
+    stepRefs.current.forEach((el) => observer.observe(el))
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div className="scrolly-container">
+      <div className="graphic" aria-hidden="true">
+        <img
+          src={sections[activeIndex].image}
+          alt={sections[activeIndex].alt}
+        />
+      </div>
+      <div className="scrolly-text">
+        {sections.map((section, i) => (
+          <section
+            key={i}
+            className={`step ${i === activeIndex ? 'active' : ''}`}
+            data-index={i}
+            ref={(el) => (stepRefs.current[i] = el)}
+          >
+            <h2>{section.title}</h2>
+            <p>{section.text}</p>
+            {section.extra && i === 1 && (
+              <div>
+                <button
+                  onClick={() => setShowMore((s) => !s)}
+                  aria-expanded={showMore}
+                  className="more-button"
+                >
+                  {showMore ? 'Hide detail' : 'Tell me more'}
+                </button>
+                {showMore && <p>{section.extra}</p>}
+              </div>
+            )}
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default ScrollyApp

--- a/src/scrolly/main.jsx
+++ b/src/scrolly/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import ScrollyApp from './ScrollyApp'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ScrollyApp />
+  </React.StrictMode>
+)

--- a/src/styles/scrolly.css
+++ b/src/styles/scrolly.css
@@ -1,0 +1,50 @@
+body {
+  margin: 0;
+  font-family: 'Inter', sans-serif;
+}
+
+.scrolly-container {
+  display: flex;
+  min-height: 100vh;
+}
+
+.graphic {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  width: 50%;
+  background: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #fff;
+}
+
+.graphic img {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.scrolly-text {
+  width: 50%;
+}
+
+.step {
+  margin: 0 auto;
+  min-height: 100vh;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  font-size: 1.25rem;
+}
+
+.step.active {
+  background-color: #f0f0f0;
+}
+
+.more-button {
+  margin-top: 1rem;
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,12 @@ export default defineConfig({
   plugins: [react()],
   base: '/greys-anatomy-report/', // updated base path
   build: {
-    outDir: 'dist'
+    outDir: 'dist',
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        scrolly: 'scrolly.html'
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- Create `scrolly.html` and supporting React components for a scroll-driven, non-technical "Heat Wave Story Mode" report
- Add dedicated styling and button-driven extra detail to keep the narrative engaging and accessible
- Configure Vite to build both the original report and the new scrolly page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 4679 problems in existing files)*
- `npm run format:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68966961a3b08328a46467d92a11f56d