### PR TITLE
Add scrollytelling alternative report

### DIFF
--- a/scrollytelling.html
+++ b/scrollytelling.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>Heat Wave Knowledge Story</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="src/scrollyMain.jsx"></script>
+  </body>
+</html>

--- a/src/ScrollyApp.jsx
+++ b/src/ScrollyApp.jsx
@@ -1,0 +1,85 @@
+/* eslint-disable no-magic-numbers */
+import { useEffect, useRef, useState } from 'react'
+import {
+  Bar,
+  BarChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts'
+
+const chartData = [
+  { group: 'Control', score: 42 },
+  { group: 'Treatment', score: 67 },
+  { group: 'Handoff', score: 73 }
+]
+
+const steps = [
+  {
+    text: 'Welcome! Scroll to explore how watching medical dramas may teach us about heat safety.'
+  },
+  {
+    text: "Viewers who saw Grey's Anatomy learned the most about staying safe during heat waves."
+  },
+  {
+    text: "Imagine if every show taught lifesaving tips — we'd all be better prepared."
+  },
+  { text: 'Stay cool and share what you learn!' }
+]
+
+export default function ScrollyApp() {
+  const [activeStep, setActiveStep] = useState(0)
+  const stepRefs = useRef([])
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            setActiveStep(Number(entry.target.dataset.index))
+          }
+        })
+      },
+      { threshold: 0.6 }
+    )
+    stepRefs.current.forEach(el => observer.observe(el))
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div className="scrolly-wrapper">
+      <div className="graphic">
+        {activeStep === 1 && (
+          <ResponsiveContainer width="100%" height={300}>
+            <BarChart data={chartData}>
+              <XAxis dataKey="group" />
+              <YAxis />
+              <Tooltip />
+              <Bar dataKey="score" fill="#ff6b6b" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+        {activeStep !== 1 && (
+          <div className="placeholder">
+            {activeStep === 0 && 'Heat safety can be dramatic!'}
+            {activeStep === 2 && 'Entertainment can save lives.'}
+            {activeStep === 3 && 'Thanks for scrolling!'}
+          </div>
+        )}
+      </div>
+      <div className="scroller">
+        {steps.map((step, i) => (
+          <section
+            className="step"
+            key={step.text}
+            data-index={i}
+            ref={el => (stepRefs.current[i] = el)}
+          >
+            <p>{step.text}</p>
+          </section>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/scrollyMain.jsx
+++ b/src/scrollyMain.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import ScrollyApp from './ScrollyApp.jsx'
+import './styles/scrolly.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ScrollyApp />
+  </React.StrictMode>
+)

--- a/src/styles/scrolly.css
+++ b/src/styles/scrolly.css
@@ -1,0 +1,49 @@
+.scrolly-wrapper {
+  display: flex;
+  align-items: flex-start;
+}
+
+.graphic {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #f9f9f9;
+  padding: 1rem;
+}
+
+.placeholder {
+  font-size: 1.5rem;
+  text-align: center;
+  line-height: 1.4;
+}
+
+.scroller {
+  flex: 1;
+  padding: 2rem;
+}
+
+.step {
+  margin: 0 auto 60vh;
+  max-width: 35ch;
+  font-size: 1.25rem;
+  line-height: 1.6;
+}
+
+@media (max-width: 768px) {
+  .scrolly-wrapper {
+    flex-direction: column;
+  }
+  .graphic {
+    height: 50vh;
+  }
+  .scroller {
+    padding: 1rem;
+  }
+  .step {
+    margin-bottom: 40vh;
+  }
+}


### PR DESCRIPTION
## Summary
- Add new `scrollytelling.html` entrypoint and `scrollyMain.jsx` to load an alternate scrollytelling report
- Implement `ScrollyApp` with scroll-driven narrative and interactive bar chart
- Include responsive scrolly-specific styles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: thousands of existing lint warnings)
- `npx eslint src/ScrollyApp.jsx src/scrollyMain.jsx`

------
https://chatgpt.com/codex/tasks/task_b_68966961a3b08328a46467d92a11f56d